### PR TITLE
chore: add hardened .npmrc and .yarnrc.yml for npm supply chain protection

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -1,0 +1,19 @@
+name: Validate supply chain config
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  validate-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate .npmrc settings
+        run: |
+          grep -q 'min-release-age=7' .npmrc
+          grep -q 'ignore-scripts=true' .npmrc
+          grep -q 'save-exact=true' .npmrc
+          grep -q 'package-lock=true' .npmrc
+      - name: Validate .yarnrc.yml settings
+        run: grep -q 'npmMinimalAgeGate: 10080' .yarnrc.yml

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -16,4 +16,5 @@ jobs:
           grep -q 'save-exact=true' .npmrc
           grep -q 'package-lock=true' .npmrc
       - name: Validate .yarnrc.yml settings
-        run: grep -q 'npmMinimalAgeGate: 10080' .yarnrc.yml
+        run: |
+          grep -q 'npmMinimalAgeGate: 10080' .yarnrc.yml

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -9,12 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Validate .npmrc settings
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Assert .npmrc settings are read by npm
         run: |
-          grep -q 'min-release-age=7' .npmrc
-          grep -q 'ignore-scripts=true' .npmrc
-          grep -q 'save-exact=true' .npmrc
-          grep -q 'package-lock=true' .npmrc
-      - name: Validate .yarnrc.yml settings
+          test "$(npm config get min-release-age)" = "7"
+          test "$(npm config get ignore-scripts)" = "true"
+          test "$(npm config get save-exact)" = "true"
+          test "$(npm config get package-lock)" = "true"
+      - name: Assert .yarnrc.yml file contains npmMinimalAgeGate setting
         run: |
           grep -q 'npmMinimalAgeGate: 10080' .yarnrc.yml

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+min-release-age=7
+ignore-scripts=true
+save-exact=true
+package-lock=true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+npmMinimalAgeGate: 10080


### PR DESCRIPTION
## Summary

Add npm supply chain attack protection configuration files to the repository root.

### Changes

- `.npmrc`: Sets 7-day minimum release age gate, disables install scripts, enforces exact versioning, and requires package-lock
- `.yarnrc.yml`: Sets `npmMinimalAgeGate: 10080` (10080 minutes = 7 days) because yarn does not read npm's `min-release-age` setting; the integer form is used because the `7d` notation has a known parsing bug

Note: The project uses Yarn Classic (1.x). `.yarnrc.yml` is only read by Yarn Berry (2+), so `npmMinimalAgeGate` is silently ignored at runtime. The file is included as a forward-compatible configuration for a future migration to Yarn Berry.

### Motivation

These settings protect against npm supply chain attacks (e.g., the Mini Shai-Hulud npm worm pattern) by:
- Refusing packages published within the last 7 days (attackers typically publish and exploit within hours)
- Preventing malicious install scripts from running during `npm install`
- Ensuring reproducible installs with exact pinned versions

### Demo

https://github.com/user-attachments/assets/c8ca4a35-7ef1-4717-8c9e-1da95116fe05

### Testing

`yarn install --frozen-lockfile` exits with code 1 due to the `lmdb-store` optional native dependency failing to compile under Node v20 (C++ API incompatibility with the old nan library). This failure is pre-existing on the master branch and is unrelated to these config changes.

Evidence comparing yarn install on master vs this branch (identical failure):

[install-evidence.txt](https://github.com/user-attachments/files/28184284/install-evidence.txt)

- close HiromiShikata/umino-corporait-operation#28792